### PR TITLE
match sneaky obsidian hardness to vanilla obsidian

### DIFF
--- a/src/main/java/net/darkhax/darkutils/features/sneaky/FeatureSneaky.java
+++ b/src/main/java/net/darkhax/darkutils/features/sneaky/FeatureSneaky.java
@@ -56,7 +56,7 @@ public class FeatureSneaky extends Feature {
         blockSneakyTorch = new BlockSneakyTorch();
         DarkUtils.REGISTRY.registerBlock(blockSneakyTorch, "sneaky_torch");
 
-        blockSneakyObsidian = new BlockSneaky().setHardness(20f).setResistance(2000f);
+        blockSneakyObsidian = new BlockSneaky().setHardness(50f).setResistance(6000f);
         DarkUtils.REGISTRY.registerBlock(blockSneakyObsidian, "sneaky_obsidian");
 
         blockSneakyPlate = new BlockSneakyPressurePlate();


### PR DESCRIPTION
Suggestion to update sneaky obsidian's hardness and blast resistance to match vanilla minecraft (50 and 6000). I noticed in my game that sneaky obsidian blocks are way easier to break. I'm trying to use them to deter entry into my base without seeing them, so having them at minecraft hardness would be especially helpful!