### PR TITLE
Fix gluttony charm side effects when equipped as Curio.

### DIFF
--- a/src/main/java/net/darkhax/darkutils/features/charms/CharmEffects.java
+++ b/src/main/java/net/darkhax/darkutils/features/charms/CharmEffects.java
@@ -91,7 +91,7 @@ public class CharmEffects {
             final Item charm = DarkUtils.content.gluttonyCharm;
             final PlayerEntity player = (PlayerEntity) event.getEntityLiving();
             
-            if (event.getItem().isFood() && PlayerUtils.getItemCountInInv(player, charm) > 0 || DarkUtils.addons.curios().hasCurioItem(charm, player)) {
+            if (event.getItem().isFood() && (PlayerUtils.getItemCountInInv(player, charm) > 0 || DarkUtils.addons.curios().hasCurioItem(charm, player))) {
                 
                 event.setDuration(0);
             }


### PR DESCRIPTION
Fix gluttony charm - was setting the duration of every used item to zero if equipped as a Curio. This was preventing bows from being fired, and potentially other issues.