### PR TITLE
Add curios support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,7 @@ repositories {
     }
     
     maven {
+
         url = "https://maven.theillusivec4.top/"
     }
 }
@@ -98,6 +99,7 @@ dependencies {
     compile fg.deobf("net.darkhax.bookshelf:Bookshelf-1.16.3:${bookshelf_version}")
     compile fg.deobf("mezz.jei:jei-1.16.2:${jei_version}")
 	compile fg.deobf("net.darkhax.runelic:Runelic-1.16.3:${runelic_version}")
+    compile fg.deobf("top.theillusivec4.curios:curios-forge:${curios_version}")
 }
 
 jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,6 +19,7 @@ mcp_version=20200916-1.16.2
 bookshelf_version=8.0.1
 jei_version=7.3.2.25
 runelic_version=5.0.1
+curios_version=1.16.3-4.0.2.0
 
 # Curse properties
 curse_versions=1.16.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ mod_at=src/main/resources/META-INF/accesstransformer.cfg
 # Dep Versions
 minecraft_version=1.16.3
 forge_version=1.16.3-34.0.1
-mcp_version=20200723-1.16.1
+mcp_version=20200916-1.16.2
 bookshelf_version=8.0.1
 jei_version=7.3.2.25
 runelic_version=5.0.1

--- a/src/main/java/net/darkhax/darkutils/DarkUtils.java
+++ b/src/main/java/net/darkhax/darkutils/DarkUtils.java
@@ -1,5 +1,7 @@
 package net.darkhax.darkutils;
 
+import net.darkhax.darkutils.addons.curios.CuriosAddon;
+import net.minecraftforge.fml.ModList;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -35,5 +37,9 @@ public class DarkUtils {
         registry = new RegistryHelper(MOD_ID, LOG).withItemGroup(ITEM_GROUP);
         content = DistExecutor.unsafeRunForDist( () -> () -> new ContentClient(registry), () -> () -> new Content(registry));
         registry.initialize(FMLJavaModLoadingContext.get().getModEventBus());
+        if (ModList.get().isLoaded("curios")) {
+
+            FMLJavaModLoadingContext.get().getModEventBus().register(CuriosAddon.class);
+        }
     }
 }

--- a/src/main/java/net/darkhax/darkutils/addons/curios/CharmCapabilityProvider.java
+++ b/src/main/java/net/darkhax/darkutils/addons/curios/CharmCapabilityProvider.java
@@ -1,0 +1,54 @@
+package net.darkhax.darkutils.addons.curios;
+
+import net.darkhax.darkutils.features.charms.ItemCharm;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Direction;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.common.util.LazyOptional;
+import top.theillusivec4.curios.api.CuriosApi;
+import top.theillusivec4.curios.api.CuriosCapability;
+import top.theillusivec4.curios.api.type.capability.ICurio;
+
+import java.util.function.BiConsumer;
+
+public class CharmCapabilityProvider implements ICapabilityProvider {
+
+    private final ItemCharm item;
+
+    private final CharmCapability cap;
+
+    private final LazyOptional<ICurio> capOptional;
+
+    public CharmCapabilityProvider(ItemCharm item) {
+
+        this.item = item;
+        this.cap = new CharmCapability();
+        this.capOptional = LazyOptional.of(() -> cap);
+    }
+
+    @Override
+    public <T> LazyOptional<T> getCapability(Capability<T> cap, Direction side) {
+
+        return CuriosCapability.ITEM.orEmpty(cap, capOptional);
+    }
+
+    class CharmCapability implements ICurio {
+        @Override
+        public void curioTick(String identifier, int index, LivingEntity livingEntity) {
+
+            CuriosApi.getCuriosHelper().findEquippedCurio(CharmCapabilityProvider.this.item, livingEntity).ifPresent(slot -> {
+
+                final BiConsumer<Entity, ItemStack> tickEffect = CharmCapabilityProvider.this.item.getInventoryTickEffect();
+
+                if (tickEffect != null) {
+
+                    tickEffect.accept(livingEntity, slot.getRight());
+                }
+
+            });
+        }
+    }
+}

--- a/src/main/java/net/darkhax/darkutils/addons/curios/CuriosAddon.java
+++ b/src/main/java/net/darkhax/darkutils/addons/curios/CuriosAddon.java
@@ -1,0 +1,64 @@
+package net.darkhax.darkutils.addons.curios;
+
+import net.darkhax.darkutils.features.charms.ItemCharm;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.common.util.LazyOptional;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.InterModComms;
+import net.minecraftforge.fml.event.lifecycle.InterModEnqueueEvent;
+import top.theillusivec4.curios.api.CuriosApi;
+import top.theillusivec4.curios.api.SlotTypeMessage;
+import top.theillusivec4.curios.api.SlotTypePreset;
+import top.theillusivec4.curios.api.type.capability.ICuriosItemHandler;
+import top.theillusivec4.curios.api.type.inventory.ICurioStacksHandler;
+import top.theillusivec4.curios.api.type.inventory.IDynamicStackHandler;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class CuriosAddon {
+    public static final String CURIOS_MOD_ID = "curios";
+
+    @SubscribeEvent
+    public static void onIMCEnqueue(InterModEnqueueEvent event) {
+
+        InterModComms.sendTo(CURIOS_MOD_ID, SlotTypeMessage.REGISTER_TYPE, SlotTypePreset.CHARM.getMessageBuilder()::build);
+    }
+
+    public static ICapabilityProvider getCapabilityProvider(ItemCharm item) {
+
+        return new CharmCapabilityProvider(item);
+    }
+
+    public static List<ItemStack> getStacksFromPlayer(PlayerEntity player, final Item item) {
+
+        final List<ItemStack> stacks = new ArrayList<>();
+
+        LazyOptional<ICuriosItemHandler> curios = CuriosApi.getCuriosHelper().getCuriosHandler(player);
+
+        curios.map(ICuriosItemHandler::getCurios).map(Map::values)
+            .ifPresent(handlers -> {
+
+                for (ICurioStacksHandler curiosStack : handlers) {
+
+                    final IDynamicStackHandler stackHandler = curiosStack.getStacks();
+
+                    for (int i = 0; i < stackHandler.getSlots(); i++) {
+
+                        final ItemStack stack = stackHandler.getStackInSlot(i);
+
+                        if (stack.getItem() == item) {
+
+                            stacks.add(stack);
+                        }
+                    }
+                }
+            });
+
+        return stacks;
+    }
+}

--- a/src/main/java/net/darkhax/darkutils/features/charms/CharmEffects.java
+++ b/src/main/java/net/darkhax/darkutils/features/charms/CharmEffects.java
@@ -2,6 +2,7 @@ package net.darkhax.darkutils.features.charms;
 
 import net.darkhax.bookshelf.util.PlayerUtils;
 import net.darkhax.darkutils.DarkUtils;
+import net.darkhax.darkutils.addons.curios.CuriosAddon;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.ServerPlayerEntity;
@@ -13,6 +14,10 @@ import net.minecraft.stats.Stats;
 import net.minecraftforge.event.entity.living.LivingEntityUseItemEvent;
 import net.minecraftforge.event.entity.living.LivingExperienceDropEvent;
 import net.minecraftforge.event.world.BlockEvent;
+import net.minecraftforge.fml.ModList;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class CharmEffects {
     
@@ -63,7 +68,7 @@ public class CharmEffects {
             final Item charm = DarkUtils.content.experienceCharm;
             final PlayerEntity player = event.getAttackingPlayer();
             
-            if (PlayerUtils.getStacksFromPlayer(player, charm).size() > 0) {
+            if (getStacksFromPlayer(player, charm).size() > 0) {
                 
                 event.setDroppedExperience(event.getDroppedExperience() + event.getEntity().world.rand.nextInt(5));
             }
@@ -77,7 +82,7 @@ public class CharmEffects {
             final Item charm = DarkUtils.content.experienceCharm;
             final PlayerEntity player = event.getPlayer();
             
-            if (PlayerUtils.getStacksFromPlayer(player, charm).size() > 0) {
+            if (getStacksFromPlayer(player, charm).size() > 0) {
                 
                 event.setExpToDrop(event.getExpToDrop() + event.getWorld().getRandom().nextInt(5));
             }
@@ -91,10 +96,24 @@ public class CharmEffects {
             final Item charm = DarkUtils.content.gluttonyCharm;
             final PlayerEntity player = (PlayerEntity) event.getEntityLiving();
             
-            if (event.getItem().isFood() && PlayerUtils.getStacksFromPlayer(player, charm).size() > 0) {
+            if (event.getItem().isFood() && getStacksFromPlayer(player, charm).size() > 0) {
                 
                 event.setDuration(1);
             }
         }
+    }
+
+    public static List<ItemStack> getStacksFromPlayer(PlayerEntity player, Item item) {
+
+        List<ItemStack> stacks = new ArrayList<>();
+
+        if (ModList.get().isLoaded("curios")) {
+
+            stacks.addAll(CuriosAddon.getStacksFromPlayer(player, item));
+        }
+
+        stacks.addAll(PlayerUtils.getStacksFromPlayer(player, item));
+
+        return stacks;
     }
 }

--- a/src/main/java/net/darkhax/darkutils/features/charms/ItemCharm.java
+++ b/src/main/java/net/darkhax/darkutils/features/charms/ItemCharm.java
@@ -5,13 +5,17 @@ import java.util.function.Consumer;
 
 import javax.annotation.Nullable;
 
+import net.darkhax.darkutils.addons.curios.CuriosAddon;
 import net.minecraft.entity.Entity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Rarity;
+import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.fml.ModList;
 
 public class ItemCharm extends Item {
     
@@ -42,5 +46,23 @@ public class ItemCharm extends Item {
             
             this.inventoryTickEffect.accept(user, stack);
         }
+    }
+
+    @Nullable
+    public BiConsumer<Entity, ItemStack> getInventoryTickEffect() {
+
+        return this.inventoryTickEffect;
+    }
+
+    @Nullable
+    @Override
+    public ICapabilityProvider initCapabilities(ItemStack stack, @Nullable CompoundNBT nbt) {
+
+        if (ModList.get().isLoaded("curios")) {
+
+            return CuriosAddon.getCapabilityProvider(this);
+        }
+
+        return null;
     }
 }

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -15,29 +15,36 @@ description='''
 ${mod_description}
 '''
 
-[[dependencies.darkutilities]]
+[[dependencies.darkutils]]
     modId="forge"
     mandatory=true
     versionRange="[34,)"
     ordering="NONE"
     side="BOTH"
 
-[[dependencies.darkutilities]]
+[[dependencies.darkutils]]
     modId="minecraft"
     mandatory=true
     versionRange="[1.16.3]"
     ordering="NONE"
     side="BOTH"
 	
-[[dependencies.darkutilities]]
+[[dependencies.darkutils]]
     modId="bookshelf"
     mandatory=true
     versionRange="[8,)"
     ordering="AFTER"
     side="BOTH"
-[[dependencies.darkutilities]]
+[[dependencies.darkutils]]
     modId="runelic"
     mandatory=true
     versionRange="[5,)"
+    ordering="AFTER"
+    side="BOTH"
+
+[[dependencies.darkutils]]
+    modId="curios"
+    mandatory=false
+    versionRange="[1.16.3-4.0.0.0,)"
     ordering="AFTER"
     side="BOTH"

--- a/src/main/resources/data/curios/tags/items/charm.json
+++ b/src/main/resources/data/curios/tags/items/charm.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "darkutils:charm_portal",
+    "darkutils:charm_sleep",
+    "darkutils:charm_experience",
+    "darkutils:charm_gluttony"
+  ]
+}


### PR DESCRIPTION
_This PR fixes #220 (maybe #221?)._

This PR re-adds support for Curios, as a soft-dependency. Currently, the charms are registered under the `charm` slot, and works when both in the inventory or in the curios slot. Also fixed the `mods.toml` dependencies section, because the declared modid and the modids in the dependencies section did not match; and updated the MCP mappings to `20200916-1.16.2`.
To achieve the inventory ticking effects, when the Curios mod is loaded, all charm items will be initialized with a capability provider and capability, which simply calls the inventory effect of the item.

I am unsure on what to add/edit in the curseforge section of your buildscript to declare a soft-dependency on Curios. I have tried to match your existing formatting for the new classes and methods. I am also thinking of adding some config option to disable the charms from working in the inventory if Curios is enabled.

Please contact me if there is something on my end which needs addressing (sciwhiz12 on the Modtoberfest or MMD discord).