### PR TITLE
[1.15.2] Fix Mod ID in mods.toml dependency blocks

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -14,21 +14,21 @@ description='''
 ${mod_description}
 '''
 
-[[dependencies.darkutilities]]
+[[dependencies.darkutils]]
     modId="forge"
     mandatory=true
     versionRange="[31,)"
     ordering="NONE"
     side="BOTH"
 
-[[dependencies.darkutilities]]
+[[dependencies.darkutils]]
     modId="minecraft"
     mandatory=true
     versionRange="[1.15.2]"
     ordering="NONE"
     side="BOTH"
 	
-[[dependencies.darkutilities]]
+[[dependencies.darkutils]]
     modId="bookshelf"
     mandatory=true
     versionRange="[5.5.33,)"


### PR DESCRIPTION
This allows Forge to detect the missing dep and display an error screen rather than trying to continue on and crashing with ClassNotFoundException